### PR TITLE
Add image placeholders to Plex documentation

### DIFF
--- a/docs/plex/browsing-and-playing.md
+++ b/docs/plex/browsing-and-playing.md
@@ -6,11 +6,15 @@ Now that you're signed in, here's how to find something to watch and control pla
 
 ### Browse the library
 
+![Plex library grid view](images/plex-library-grid.png){ width="600" }
+
 On the left side of the screen (or in the menu on mobile), you'll see the shared libraries -- usually labeled something like **"Movies"** and **"TV Shows."** Tap or click one to see everything available.
 
 Inside a library, content is displayed as a grid of poster artwork. You can scroll through to see what's available, much like browsing Netflix or any other streaming app.
 
 ### Use search
+
+![Plex search bar](images/plex-search.png){ width="600" }
 
 Look for the **magnifying glass icon** at the top of the screen. Type the name of a movie, show, or actor, and Plex will show you matching results from the shared server.
 
@@ -24,6 +28,8 @@ Inside any library, look for **sort** and **filter** options near the top of the
 
 ## Playing something
 
+![Plex title detail page](images/plex-detail-page.png){ width="600" }
+
 1. **Click or tap a title** to open its detail page. You'll see a description, rating, cast info, and the play button.
 2. **Press the big Play button** to start watching immediately. For TV shows, you'll see a list of seasons and episodes -- pick the one you want and press play.
 3. **Playback controls** appear when you move your mouse (or tap the screen on mobile). You'll see familiar buttons: play/pause, skip forward/back, volume, and fullscreen.
@@ -33,6 +39,8 @@ Inside any library, look for **sort** and **filter** options near the top of the
     If you stop watching partway through, Plex remembers where you left off. Next time you open that title, just press **"Resume"** to pick up right where you stopped.
 
 ## Subtitles & audio
+
+![Plex playback controls](images/plex-playback-controls.png){ width="600" }
 
 During playback, look for a **speech bubble icon** or **settings gear** in the playback controls. From there you can:
 

--- a/docs/plex/devices.md
+++ b/docs/plex/devices.md
@@ -69,6 +69,8 @@ This is the easiest way to watch -- no app needed.
 
 ## Linking any device -- the universal method
 
+![Plex device link code screen](images/plex-link-code.png){ width="600" }
+
 Nearly every Plex app on a TV or streaming device uses the same linking process:
 
 1. Install and open the Plex app on your device. A **4-letter code** appears on screen.

--- a/docs/plex/getting-started.md
+++ b/docs/plex/getting-started.md
@@ -4,6 +4,8 @@ Create your free account, accept your invitation, and start watching. The whole 
 
 ## Step 1 -- Create your free Plex account
 
+![Plex sign-up page](images/plex-signup.png){ width="600" }
+
 1. Open a web browser on your computer, phone, or tablet and go to: **[plex.tv/sign-up](https://www.plex.tv/sign-up/)**
 2. You can sign up using your **email address**, or sign in with Google, Facebook, or Apple. Use whichever you're most comfortable with.
 3. Choose a **username** and **password** you'll remember. Write them down if it helps!
@@ -14,6 +16,8 @@ Create your free account, accept your invitation, and start watching. The whole 
     If you used an email address to sign up, check your inbox for a confirmation email from Plex and click the link inside. Check your spam folder if you don't see it.
 
 ## Step 2 -- Accept the server invitation
+
+![Plex invitation email](images/plex-invitation.png){ width="600" }
 
 The server owner will send you a **friend invitation** through Plex. Here's how to find and accept it:
 
@@ -26,6 +30,8 @@ The server owner will send you a **friend invitation** through Plex. Here's how 
     Ask the server owner to re-send the invitation. Make sure they have the same email address you used to create your Plex account. Also check your spam/junk folder.
 
 ## Step 3 -- Sign in and start watching
+
+![Plex sidebar with shared libraries](images/plex-sidebar-libraries.png){ width="600" }
 
 1. Go to **[app.plex.tv](https://app.plex.tv)** in any web browser.
 2. Sign in with your account.

--- a/docs/plex/index.md
+++ b/docs/plex/index.md
@@ -1,5 +1,7 @@
 # Welcome to My Plex Server
 
+![Plex home screen](images/plex-home.png){ width="600" }
+
 You've been invited to stream movies, TV shows, and more -- all for free.
 This short guide will help you get set up and watching in minutes.
 


### PR DESCRIPTION
Add placeholder image references across all Plex guide pages for screenshots of the Plex UI (home screen, sign-up, library, search, playback controls, device linking, etc.).