### PR TITLE
Add Plex requesting content page for Pulsarr

### DIFF
--- a/docs/plex/index.md
+++ b/docs/plex/index.md
@@ -17,6 +17,7 @@ Pick the guide that matches where you are right now:
 - **[Getting Started](getting-started.md)** -- Create your free Plex account, accept your invitation, and sign in for the first time. Takes about 5 minutes.
 - **[Browsing & Playing](browsing-and-playing.md)** -- Learn how to find movies and shows, use search, manage your watchlist, and control playback.
 - **[Setting Up Your Devices](devices.md)** -- Step-by-step instructions for watching on your TV, phone, tablet, or computer.
+- **[Requesting Content](requesting-content.md)** -- How to request new movies and TV shows by adding them to your Plex watchlist.
 
 ---
 

--- a/docs/plex/requesting-content.md
+++ b/docs/plex/requesting-content.md
@@ -1,0 +1,32 @@
+# Requesting Content
+
+Want to watch something that isn't on the server yet? You can request it directly from Plex -- no extra apps or accounts needed.
+
+## How it works
+
+This server uses **Pulsarr** to automatically monitor your Plex watchlist. When you add a movie or TV show to your watchlist, Pulsarr detects it and begins downloading it to the server. In most cases, the content will appear in your library within a few minutes to a few hours depending on availability.
+
+## How to request something
+
+1. Search for the movie or TV show you want in Plex (even if it's not on the server yet, Plex will show results from its online database).
+2. Open the title's detail page.
+3. Click the **"Add to Watchlist"** button (the bookmark icon).
+4. That's it -- Pulsarr will pick up your request automatically.
+
+!!! tip
+
+    You can manage your watchlist from any Plex app or from [app.plex.tv](https://app.plex.tv). Anything you add will be detected.
+
+## What to expect
+
+- **Movies** are typically available within a few hours of being requested.
+- **TV shows** will be monitored for new episodes automatically once added.
+- If something isn't available or can't be found, reach out to the server owner.
+
+!!! note
+
+    Not every request can be fulfilled. Some content may not be available due to region restrictions, release timing, or other limitations. If your request doesn't show up after a day or so, just ask the server owner.
+
+## Removing a request
+
+If you change your mind, simply remove the title from your Plex watchlist. You can do this from the title's detail page by clicking the bookmark icon again.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,5 +50,6 @@ nav:
     - Getting Started: plex/getting-started.md
     - Browsing & Playing: plex/browsing-and-playing.md
     - Devices: plex/devices.md
+    - Requesting Content: plex/requesting-content.md
   - Reference:
     - FAQ: reference/faq.md


### PR DESCRIPTION
Explain how users can request new movies and TV shows by adding them to their Plex watchlist, which Pulsarr monitors automatically.